### PR TITLE
Update MySensors.MySGW `init` return for state to be a map

### DIFF
--- a/lib/my_sensors.mysgw.ex
+++ b/lib/my_sensors.mysgw.ex
@@ -27,7 +27,7 @@ defmodule MySensors.MySGW do
       {:args, ["-d"]}
     ]
     port = Port.open({:spawn_executable, exe}, port_opts)
-    {:ok, port}
+    {:ok, %{port: port}}
   end
 
   def handle_info({_port, {:data, {:eol, data}}}, state) do


### PR DESCRIPTION
`init` returned `port` for the state, but in the terminate
it is attempting to use `state.port` if it existed.

Instead of changing terminate to just look for the port as
the state, this updates the setup of the state to not just
be the port, as it allows it to be more extensible in the
future.